### PR TITLE
Update misue of YYYY weekyear for calendar year yyyy.

### DIFF
--- a/okhttp/src/test/java/okhttp3/CacheTest.java
+++ b/okhttp/src/test/java/okhttp3/CacheTest.java
@@ -1397,7 +1397,7 @@ public final class CacheTest {
     // Serve a response with a non-standard date format that OkHttp supports.
     Date lastModifiedDate = new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(-1));
     Date servedDate = new Date(System.currentTimeMillis() + TimeUnit.HOURS.toMillis(-2));
-    DateFormat dateFormat = new SimpleDateFormat("EEE dd-MMM-YYYY HH:mm:ss z", Locale.US);
+    DateFormat dateFormat = new SimpleDateFormat("EEE dd-MMM-yyyy HH:mm:ss z", Locale.US);
     dateFormat.setTimeZone(TimeZone.getTimeZone("America/New_York"));
     String lastModifiedString = dateFormat.format(lastModifiedDate);
     String servedString = dateFormat.format(servedDate);


### PR DESCRIPTION
Week year is intended to be used for week dates, eg 2015-W01-1, it is often mistakenly used for calendar dates, in which case the year may be incorrect during the last week of the year 


[_Created by Sourcegraph campaign `christine/fix-misused-weekyear`._](https://demo.sourcegraph.com/users/christine/campaigns/fix-misused-weekyear)